### PR TITLE
fix: error caused by tailwind.config.js

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,6 @@ module.exports = {
       './pages/**/*.vue',
       './app.vue',
       './plugins/**/*.{js,ts}',
-      './nuxt.config.{js,ts}',
     ],
   },
   theme: {


### PR DESCRIPTION
'./nuxt.config.{js,ts}'  cause an error in vite CLI: 
` ERROR  Importing directly from a nuxt.config file is not allowed. Instead, use runtime config or a module. [importing /nuxt.config.js from index.html]`


This parameter is not needed as seen in this post: 
https://github.com/nuxt/nuxt.js/issues/13278

