### PR TITLE
fix:  language persistence

### DIFF
--- a/components/locale/switcher.vue
+++ b/components/locale/switcher.vue
@@ -4,6 +4,7 @@
       <select
         v-model="$i18n.locale"
         class="form-select uppercase w-13 h-12 rounded-lg block w-full px-3 py-1.5 text-base font-normal text-slate-500 bg-white-500 bg-clip-padding bg-no-repeat border border-solid border-slate-200 transition ease-in-out m-0 focus:text-slate-500 focus:bg-white-500 focus:border-royal-blue-600 focus:outline-none"
+        @change="storeLocale"
       >
         <option
           v-for="(locale, i) in $i18n.availableLocales"
@@ -16,3 +17,15 @@
     </div>
   </div>
 </template>
+<script>
+export default {
+  setup() {
+    function storeLocale(e) {
+      localStorage.setItem('currentLocale', e.target.value)
+    }
+    return {
+      storeLocale,
+    }
+  },
+}
+</script>

--- a/utils/browserLanguage.js
+++ b/utils/browserLanguage.js
@@ -1,17 +1,17 @@
 export function getBrowserLocale() {
-  const countryCodeOnly = true
+  const currentLocale = localStorage.getItem('currentLocale')
   const navigatorLocale =
     navigator.languages !== undefined
       ? navigator.languages[0]
       : navigator.language
 
-  if (!navigatorLocale) {
+  if (!navigatorLocale && !currentLocale) {
     return undefined
   }
 
-  const trimmedLocale = countryCodeOnly
+  const trimmedLocale = navigatorLocale
     ? navigatorLocale.trim().split(/-|_/)[0]
     : navigatorLocale.trim()
 
-  return trimmedLocale
+  return currentLocale || trimmedLocale
 }


### PR DESCRIPTION
As a user, I want the language of the page to be the same when I reload it. see https://trello.com/c/v7g58xNS/405-persist-translation-language

## Acceptance Criteria
- [ ] Selected language is persisted when page is reloaded


## Demo
-https://deploy-preview-79--wehelpvip.netlify.app/